### PR TITLE
Avoid memorystream

### DIFF
--- a/driver/normalizer/annotation.go
+++ b/driver/normalizer/annotation.go
@@ -18,6 +18,8 @@ var Code = []CodeTransformer{
 	positioner.NewFillLineColFromOffset(),
 }
 
+var PreprocessCode = []CodeTransformer{}
+
 func annotateTypeToken(typ, token string, roles ...role.Role) Mapping {
 	return AnnotateType(typ,
 		FieldRoles{

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.11.1</version>
+            <version>2.8.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/native/src/main/java/tech/sourced/babelfish/DriverResponse.java
+++ b/native/src/main/java/tech/sourced/babelfish/DriverResponse.java
@@ -38,12 +38,16 @@ public class DriverResponse {
         translationUnit = parser.parseCPP(source);
     }
 
+    // Note: since we're using the System.out output stream with Jackson, output will
+    // start to be written before this call so its not a deterministic "send everything".
+    // The reason to not use a ByteArrayOutputStream and send everything in one go is that
+    // sometimes memory can grow too much with some files.
     void send() throws ResponseSendException {
         // FIXME: this includes the errors in the already started document
         try {
             formatWritter.writeValue(this);
-            ByteArrayOutputStream byteOut = formatWritter.getByteOutputStream();
-            System.out.write(byteOut.toByteArray());
+            OutputStream byteOut = formatWritter.getOutputStream();
+            byteOut.flush();
             System.out.write('\n');
         } catch (IOException e) {
             throw new DriverResponse.ResponseSendException(e);

--- a/native/src/main/java/tech/sourced/babelfish/IExchangeFormatWritter.java
+++ b/native/src/main/java/tech/sourced/babelfish/IExchangeFormatWritter.java
@@ -1,6 +1,6 @@
 package tech.sourced.babelfish;
 
-import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import java.io.IOException;
 
 /**
@@ -10,5 +10,5 @@ import java.io.IOException;
 public interface IExchangeFormatWritter
 {
     void writeValue(DriverResponse response) throws IOException;
-    ByteArrayOutputStream getByteOutputStream();
+    OutputStream getOutputStream();
 }

--- a/native/src/main/java/tech/sourced/babelfish/Main.java
+++ b/native/src/main/java/tech/sourced/babelfish/Main.java
@@ -20,7 +20,7 @@ public class Main {
     private static ProcessCycle trySendError(String msg, Exception e) {
         try {
             final TranslationUnitJSONMapper responseJSONMapper =
-                    new TranslationUnitJSONMapper(false, new ByteArrayOutputStream());
+                    new TranslationUnitJSONMapper(false, System.out);
             DriverResponse response = new DriverResponse(responseJSONMapper);
             response.sendError(e, msg);
             return ProcessCycle.CONTINUE;
@@ -38,7 +38,7 @@ public class Main {
         try {
             final EclipseCPPParser parser = new EclipseCPPParser();
             final TranslationUnitJSONMapper responseJSONMapper =
-                new TranslationUnitJSONMapper(false, new ByteArrayOutputStream());
+                new TranslationUnitJSONMapper(false, System.out);
             response = new DriverResponse(responseJSONMapper);
 
             BufferedReader in = new BufferedReader(new InputStreamReader(System.in));

--- a/native/src/main/java/tech/sourced/babelfish/TranslationUnitJSONMapper.java
+++ b/native/src/main/java/tech/sourced/babelfish/TranslationUnitJSONMapper.java
@@ -19,7 +19,7 @@ class TranslationUnitJSONMapper implements IExchangeFormatWritter {
     final JsonGenerator generator;
     final JsonFactory jsonFactory = new JsonFactory();
     final ObjectMapper mapper = new ObjectMapper();
-    private PrintStream printStream;
+    private OutputStream printStream;
 
     TranslationUnitJSONMapper(boolean prettyPrint, PrintStream byteOutput) throws IOException {
         this.printStream = byteOutput;

--- a/native/src/main/java/tech/sourced/babelfish/TranslationUnitJSONMapper.java
+++ b/native/src/main/java/tech/sourced/babelfish/TranslationUnitJSONMapper.java
@@ -10,7 +10,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 
-import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.io.IOException;
 
 class TranslationUnitJSONMapper implements IExchangeFormatWritter {
@@ -18,12 +19,12 @@ class TranslationUnitJSONMapper implements IExchangeFormatWritter {
     final JsonGenerator generator;
     final JsonFactory jsonFactory = new JsonFactory();
     final ObjectMapper mapper = new ObjectMapper();
-    private ByteArrayOutputStream byteOutputStream;
+    private PrintStream printStream;
 
-    TranslationUnitJSONMapper(boolean prettyPrint, ByteArrayOutputStream byteOutput) throws IOException {
-        this.byteOutputStream = byteOutput;
+    TranslationUnitJSONMapper(boolean prettyPrint, PrintStream byteOutput) throws IOException {
+        this.printStream = byteOutput;
 
-        generator = jsonFactory.createGenerator(byteOutputStream);
+        generator = jsonFactory.createGenerator(printStream);
         if (prettyPrint) {
             generator.setPrettyPrinter(new DefaultPrettyPrinter());
             mapper.enable(SerializationFeature.INDENT_OUTPUT);
@@ -40,7 +41,7 @@ class TranslationUnitJSONMapper implements IExchangeFormatWritter {
         mapper.writeValue(generator, response);
     }
 
-    public ByteArrayOutputStream getByteOutputStream() {
-        return byteOutputStream;
+    public OutputStream getOutputStream() {
+        return printStream;
     }
 }


### PR DESCRIPTION
- Used the hint nicely provided by @dennwc on #22 to avoid holding all the output in memory in the Java side. Unfortunately this doesn't fix the high memory usage, just seem to move it to the SDK/non JVM (and the file provided in #19 still causes an unnatural time/memory usage), so there is still work to do, but at least Java don't crash with an OOM anymore, so fixes #22. I'll still keep #19 open so we don't forget to continue investigating what is causing that memory usage with that file.

- Security update of a dependency to remove a warning from Github. Looks like Jackson has weekly security issues.

- Adds the new `PreprocessCode` to the annotations.go.